### PR TITLE
Modernise TeamTools quality gates

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,46 +1,55 @@
 name: CI, CD & Auto-Merge
 
 on:
-  push:           # Runs tests on ALL branches whenever code is pushed
-  pull_request:   # Runs tests on ALL pull requests (including Dependabot)
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
-  # -------------------------------------------------------------
-  # JOB 1: Run Tests & Deploy to Vercel
-  # -------------------------------------------------------------
   ci-pipeline:
+    name: Lint, test, build and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
-          cache: 'npm'
+          node-version-file: package.json
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Tests
+      - name: Lint and type-check
+        run: npm run lint
+
+      - name: Run tests
         run: npm run test:ci
 
-      # --- VERCEL DEPLOYMENTS (Only run if tests passed above) ---
-      
+      - name: Build
+        run: npm run build
+
       - name: Install Vercel CLI
         if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
         run: npm install --global vercel@latest
 
-      # Preview Deployment (Only for Pull Requests)
       - name: Deploy Preview to Vercel
         if: github.event_name == 'pull_request'
         run: |
@@ -48,7 +57,6 @@ jobs:
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
-      # Production Deployment (Only when pushed/merged into main)
       - name: Deploy Production to Vercel
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
@@ -56,13 +64,13 @@ jobs:
           vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
-  # -------------------------------------------------------------
-  # JOB 2: Auto-Merge Dependabot (Waits for Job 1 to finish)
-  # -------------------------------------------------------------
   auto-merge:
     runs-on: ubuntu-latest
-    needs: ci-pipeline  # <-- CRITICAL: Prevents merging until tests pass
+    needs: ci-pipeline
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,24 @@
 {
   "name": "teamtools",
+  "description": "Anonymous team health and Tuckman-stage voting tool",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:ci": "vitest run",
+    "test:watch": "vitest",
+    "test:update": "vitest -u",
+    "check": "npm run lint && npm test && npm run build"
+  },
   "dependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
@@ -20,25 +39,9 @@
     "rxjs": "^7.8.2",
     "typescript": "^7.0.2"
   },
-  "description": "Start mini server",
-  "version": "1.0.0",
-  "main": "index.js",
-  "type": "module",
-  "scripts": {
-    "start": "vite",
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "test": "vitest",
-    "test:ci": "vitest run",
-    "test:update": "vitest -u"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/digiguru/TeamTools.git"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   },
   "browserslist": {
     "production": [
@@ -54,7 +57,6 @@
   },
   "author": "digiguru",
   "license": "MIT",
-  "homepage": "https://teamtools.herokuapp.com/",
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.5",
     "acorn": "^8.18.0",

--- a/readme.md
+++ b/readme.md
@@ -1,37 +1,121 @@
-# Team Tools
+# TeamTools
 
-TeamTools is a migration of an old project to help teams vote on the tuckman model in an anonymous fashion, but get instant results.
+TeamTools is a lightweight team-health application for anonymously capturing where people think a team sits in the Tuckman model and showing the combined result immediately.
 
-It was originally created in RaphaelJS, but has gone through a number of iteractions (including D3) to end up as a ReactApp in Typescript using raw SVG.
+The project started as a RaphaelJS experiment, moved through D3, and is now a React + TypeScript application rendered with SVG.
 
-See a [demo of it running](https://teamtools.herokuapp.com/) at Heroku.
+## Tech stack
 
-## Tasks
-
-- [x] CI/CD
-- [x] Unit Test results in CI/CD
-- [x] Add Users
-- [x] Delete Users
-- [x] Don't allow add of users with the same name
-- [ ] Link user entry up with application
-- [ ] Get tests useful & working
-- [x] Force tests to pass before builds get deployed
-- [x] Fix the entry page (was hashed together in vanilla javascript and hasn't yet been migrated)
-- [ ] Work out errors when 3 people log their data
-- [ ] Add socket integration
-- [x] Purge redundant code
+- React 19
+- TypeScript 7
+- Vite 8
+- Redux / React Redux
+- RxJS
+- Vitest and Testing Library
+- Vercel for deployment
+- Node.js 24
 
 ## Development
 
-1) Install node
-2) Checkout code
-3) `npm i`
-4) `npm start`
+Requirements:
 
-To deploy to live, just commit changes to `Master` on https://github.com/digiguru/TeamTools
+- Node.js 24
+- npm
 
-Run the tests localy
+Install dependencies and start the development server:
 
 ```bash
-npm test
+npm ci
+npm run dev
 ```
+
+Vite will print the local development URL, normally `http://localhost:5173`.
+
+## Quality checks
+
+Run the full local validation with:
+
+```bash
+npm run check
+```
+
+Or run each stage independently:
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+
+`npm run lint` performs a full TypeScript type-check with `tsc --noEmit`. This is currently a more useful static-analysis gate for this TypeScript-heavy codebase than preserving the obsolete Create React App ESLint configuration that the project previously carried.
+
+## Tests
+
+The Vitest suite covers the core team models and shared behaviours, including:
+
+- Comfort model behaviour
+- Tuckman model behaviour
+- cache behaviour
+- construction and filtering of users
+
+Use watch mode while developing:
+
+```bash
+npm run test:watch
+```
+
+CI uses:
+
+```bash
+npm run test:ci
+```
+
+Tests should focus on behaviour rather than implementation details. New reducers, transformations and user-visible flows should normally gain tests in the same change.
+
+## CI/CD
+
+GitHub Actions runs on pull requests and pushes to `main` using Node 24. The validation pipeline runs:
+
+1. `npm ci`
+2. TypeScript static analysis
+3. the Vitest suite
+4. the Vite production build
+
+A successful pull request can then be deployed as a Vercel preview. Pushes to `main` deploy to production when the required Vercel secrets are configured.
+
+Dependabot pull requests can be auto-merged only after the CI pipeline succeeds.
+
+## Project structure
+
+- `src/Entry/` — entry/user onboarding UI
+- `src/React/Comfort/` — comfort model state and UI
+- `src/React/Tuckman/` — Tuckman model state and UI
+- `src/React/*Zone/` — visualisation and interaction areas
+- `src/Shared/` — reusable browser, user, cache and geometry utilities
+- `src/**/__tests__/` — Vitest suites
+- `vite.config.ts` — Vite and test configuration
+- `vercel.json` — Vercel deployment configuration
+
+## Deployment
+
+Production assets are generated with:
+
+```bash
+npm run build
+```
+
+The current deployment target is Vercel. The old Heroku references and `Procfile` are historical leftovers and are not the primary deployment path.
+
+## Contributing
+
+Keep pull requests small where practical. Before opening or merging one, run:
+
+```bash
+npm run check
+```
+
+Do not weaken tests merely to get CI green; fix the behaviour or update the expectation when the intended behaviour has genuinely changed.
+
+## License
+
+MIT — see `LICENSE`.

--- a/src/React/Comfort/Reducer.ts
+++ b/src/React/Comfort/Reducer.ts
@@ -1,131 +1,120 @@
-
 import { ComfortActions } from "./Actions";
 import { ComfortAppState } from "./Model";
 import { Point } from "../Models/Point";
 import { Size } from "../Models/Size";
 import { DOMMeasurement } from "../Models/IDomMeasurement";
-import { IUser, IUserList } from "../User/Model";
-import { fromJS, List, Map } from "immutable";
+import { IUser, IUserList, IUserUI } from "../User/Model";
 
 const initialSize: Size = new Size(800, 800);
 const initialState: ComfortAppState = {
-    Size       : initialSize,
+    Size: initialSize,
     CenterPoint: new Point(initialSize.width / 2, initialSize.height / 2),
-    UserList   : {
-    ShowUsers  : true,
-    Users      : [
-            {Username: "Adam Hall", Focus: "not-in-focus", Y: 0 },
-            {Username: "Caroline Hall", Focus: "not-in-focus", Y: 0 }
+    UserList: {
+        ShowUsers: true,
+        Users: [
+            {Username: "Adam Hall", Focus: "not-in-focus", Y: 0},
+            {Username: "Caroline Hall", Focus: "not-in-focus", Y: 0}
         ]
     },
-    Zones      : {
+    Zones: {
         Comfort: {Name: "Comfort", Focus: "not-in-focus", Range: {Start: 0, End: 33}, Size: {Width: new DOMMeasurement("50%"), Height: new DOMMeasurement("50%")}},
         Stretch: {Name: "Stretch", Focus: "not-in-focus", Range: {Start: 34, End: 66}, Size: {Width: new DOMMeasurement("50%"), Height: new DOMMeasurement("50%")}},
-        Chaos  : {Name: "Chaos", Focus: "not-in-focus", Range: {Start: 67, End: 100}, Size: {Width: new DOMMeasurement("100%"), Height: new DOMMeasurement("100%")}}
+        Chaos: {Name: "Chaos", Focus: "not-in-focus", Range: {Start: 67, End: 100}, Size: {Width: new DOMMeasurement("100%"), Height: new DOMMeasurement("100%")}}
     },
     ShowUserChoices: false,
-    UserChoices    : []
+    UserChoices: []
 };
+
 export function comfortReducer(state: ComfortAppState = initialState, action): ComfortAppState {
     switch (action.type) {
         case ComfortActions.SET_USERLIST:
-            return ComfortZoneAction.setUsers(state, (action as any).userList);
+            return ComfortZoneAction.setUsers(state, action.userList);
         case ComfortActions.SET_STAGEVISIBILITY:
-            return ComfortZoneAction.setVisibility(state, (action as any).visibility);
+            return ComfortZoneAction.setVisibility(state, action.visibility);
         case ComfortActions.SET_STAGESIZE:
-            return ComfortZoneAction.setStageSize(state, (action as any).width, (action as any).height);
+            return ComfortZoneAction.setStageSize(state, action.width, action.height);
         case ComfortActions.SET_USERFOCUS:
-            return ComfortZoneAction.setUserFocus(state, (action as any).user, (action as any).focus);
+            return ComfortZoneAction.setUserFocus(state, action.user, action.focus);
         case ComfortActions.SET_ZONEFOCUS:
-            return ComfortZoneAction.setZoneFocus(state, (action as any).area, (action as any).focus);
+            return ComfortZoneAction.setZoneFocus(state, action.area, action.focus);
         case ComfortActions.SELECT_USER:
-            return ComfortZoneAction.selectUser(state, (action as any).user);
+            return ComfortZoneAction.selectUser(state, action.user);
         case ComfortActions.CHOOSE_ZONE:
-            return ComfortZoneAction.chooseZone(state, (action as any).user, (action as any).area, (action as any).distance);
+            return ComfortZoneAction.chooseZone(state, action.user, action.area, action.distance);
         case ComfortActions.TOGGLE_CHOICES:
-            return ComfortZoneAction.toggleChoiceVisibility(state, (action as any).visible);
+            return ComfortZoneAction.toggleChoiceVisibility(state, action.visible);
         default:
             return state;
     }
 }
+
 class ComfortZoneAction {
-    static setStageSize(state: ComfortAppState, width: number, height: number) {
-        const newCenter = new Point(width / 2, height / 2);
-        return fromJS(state)
-            .set("Size", new Size(width, height))
-            .set("CenterPoint", newCenter)
-            .toJS();
+    static setStageSize(state: ComfortAppState, width: number, height: number): ComfortAppState {
+        return {
+            ...state,
+            Size: new Size(width, height),
+            CenterPoint: new Point(width / 2, height / 2)
+        };
     }
-    static setVisibility(state: ComfortAppState, visibility: "hiding" | "appearing") {
-        return fromJS(state)
-            .setIn(["Zones", "Comfort", "visibility"], visibility)
-            .setIn(["Zones", "Stretch", "visibility"], visibility)
-            .setIn(["Zones", "Chaos", "visibility"], visibility).toJS();
-        //  state.Zones.Chaos.visibility
+
+    static setVisibility(state: ComfortAppState, visibility: "hiding" | "appearing"): ComfortAppState {
+        return {
+            ...state,
+            Zones: {
+                ...state.Zones,
+                Comfort: {...state.Zones.Comfort, visibility},
+                Stretch: {...state.Zones.Stretch, visibility},
+                Chaos: {...state.Zones.Chaos, visibility}
+            }
+        };
     }
 
     static setZoneFocus(state: ComfortAppState, area: "Chaos" | "Stretch" | "Comfort", focus: "in-focus" | "active" | "not-in-focus"): ComfortAppState {
-        return fromJS(state)
-            .setIn(["Zones", "Comfort", "Focus"], area === "Comfort" ? focus : "not-in-focus")
-            .setIn(["Zones", "Stretch", "Focus"], area === "Stretch"  ? focus : "not-in-focus")
-            .setIn(["Zones", "Chaos", "Focus"], area === "Chaos"  ? focus : "not-in-focus").toJS();
+        return {
+            ...state,
+            Zones: {
+                ...state.Zones,
+                Comfort: {...state.Zones.Comfort, Focus: area === "Comfort" ? focus : "not-in-focus"},
+                Stretch: {...state.Zones.Stretch, Focus: area === "Stretch" ? focus : "not-in-focus"},
+                Chaos: {...state.Zones.Chaos, Focus: area === "Chaos" ? focus : "not-in-focus"}
+            }
+        };
     }
 
     static setUserFocus(state: ComfortAppState, user: string, focus: "in-focus" | "active" | "not-in-focus"): ComfortAppState {
-        const originalList = List(state.UserList.Users);
-        const newUserList = originalList.update(
-            originalList.findIndex(item => item.Username === user),
-            (item) => fromJS(item).set("Focus", focus)).toJS();
-        return fromJS(state)
-            .setIn(["UserList", "Users"], newUserList).toJS();
+        const users = (state.UserList.Users ?? []).map((item) =>
+            item.Username === user ? {...item, Focus: focus, Y: "Y" in item ? item.Y : 0} as IUserUI : item
+        );
+        return {...state, UserList: {...state.UserList, Users: users}};
     }
-    static selectUser(state: ComfortAppState, user: String): ComfortAppState {
-        const originalList = List(state.UserList.Users);
-        const item: IUser = originalList.find(item => item.Username === user);
-        // Sets currentUser, and therefor hides the user choice menu
-        const data = fromJS(state)
-            .set("CurrentUser", item)
-            .set("ShowUserChoices", false)
-            .setIn(["UserList", "ShowUsers"], false);
 
-        return data.toJS();
+    static selectUser(state: ComfortAppState, user: string): ComfortAppState {
+        const item = (state.UserList.Users ?? []).find(candidate => candidate.Username === user) as IUser | undefined;
+        return {
+            ...state,
+            CurrentUser: item,
+            ShowUserChoices: false,
+            UserList: {...state.UserList, ShowUsers: false}
+        };
     }
 
     static setUsers(state: ComfortAppState, userList: IUserList): ComfortAppState {
-        console.log("Input", state.UserList);
-        console.log("Update", userList);
-
-        const data = fromJS(state)
-            .set("UserList", userList).toJS();
-        console.log("Output", data.UserList);
-        return data;
+        return {...state, UserList: userList};
     }
 
-    static chooseZone(
-        state: ComfortAppState, user: string, area: "Chaos" | "Stretch" | "Comfort",
-        distance: number): ComfortAppState {
-
-        // Add the user choice
-        const newUserChoices = List(state.UserChoices).push({
-            User: {Username: user},
-            Zone: area,
-            Distance: distance
-        }).toJS();
-        // Remove the user from the choice list
-        const newUserList = List(state.UserList.Users).filter((item) => item.Username !== user).toArray();
-        // Show the user list
-        const showUserChoice = !!(newUserList.length);
-        // Return
-        return fromJS(state)
-            .delete("CurrentUser")
-            .set("ShowUserChoices", showUserChoice)
-            .set("UserChoices", newUserChoices)
-            .setIn(["UserList", "Users"], newUserList)
-            .setIn(["UserList", "ShowUsers"], showUserChoice).toJS();
+    static chooseZone(state: ComfortAppState, user: string, area: "Chaos" | "Stretch" | "Comfort", distance: number): ComfortAppState {
+        const newUserList = (state.UserList.Users ?? []).filter((item) => item.Username !== user);
+        const showUserChoice = newUserList.length > 0;
+        return {
+            ...state,
+            CurrentUser: undefined,
+            ShowUserChoices: showUserChoice,
+            UserChoices: [...state.UserChoices, {User: {Username: user}, Zone: area, Distance: distance}],
+            UserList: {...state.UserList, Users: newUserList, ShowUsers: showUserChoice}
+        };
     }
+
     static toggleChoiceVisibility(state: ComfortAppState, visible: boolean): ComfortAppState {
-        // Set "showUserChoices" to true
-        return Map(state)
-            .set("ShowUserChoices", visible).toJS();
+        return {...state, ShowUserChoices: visible};
     }
 }

--- a/src/React/ComfortZone/Model.ts
+++ b/src/React/ComfortZone/Model.ts
@@ -28,8 +28,9 @@ export interface IComfortZoneConnectorWithEvents extends IComfortZoneConnector {
     Events       : IComfortZoneEvents;
 }
 export class ComfortZoneState {
-    Name  : "Chaos" | "Stretch" | "Comfort";
-    Focus?: "in-focus" | "active" | "not-in-focus";
-    Range?: ComfortZoneRangeState;
-    Size? : ISizable;
+    Name       : "Chaos" | "Stretch" | "Comfort";
+    Focus?     : "in-focus" | "active" | "not-in-focus";
+    visibility?: "hiding" | "appearing";
+    Range?     : ComfortZoneRangeState;
+    Size?      : ISizable;
 }

--- a/src/React/Tuckman/Model.ts
+++ b/src/React/Tuckman/Model.ts
@@ -1,14 +1,16 @@
-import { IDOMMeasurement } from "../Models/IDomMeasurement";
+import { Point } from "../Models/Point";
 import { IStageState } from "../Stage/Model";
 import { IUserList, IUser } from "../User/Model";
 import { ITuckmanZone } from "../TuckmanZone/Model";
 
 export interface ITuckmanModel extends IStageState {
-    zones?       : ITuckmanZoneList;
-    CurrentUser? : IUser;
-    UserList?    : IUserList;
-    UserChoices? : Array<ITuckmanUserChoiceState>;
-    visibility   : boolean;
+    zones?          : ITuckmanZoneList;
+    CenterPoint?    : Point;
+    CurrentUser?    : IUser;
+    UserList?       : IUserList;
+    UserChoices?    : Array<ITuckmanUserChoiceState>;
+    ShowUserChoices?: boolean;
+    visibility      : boolean;
 }
 
 export interface ITuckmanZoneList {
@@ -17,8 +19,9 @@ export interface ITuckmanZoneList {
     norming   : ITuckmanZone;
     performing: ITuckmanZone;
 }
+
 export interface ITuckmanUserChoiceState {
     User    : IUser;
-    zone    : "forming" | "storming" | "norming" | "performing";
+    Zone    : "forming" | "norming" | "performing" | "storming";
     Distance: number;
 }

--- a/src/React/Tuckman/Reducer.ts
+++ b/src/React/Tuckman/Reducer.ts
@@ -1,149 +1,119 @@
-
-// import {ComfortActions} from "./Actions";
-import { ITuckmanModel } from "./Model"; // ITuckmanZoneList }
-// import { DOMMeasurement } from "../Models/IDomMeasurement";
+import { ITuckmanModel } from "./Model";
 import { Size } from "../Models/Size";
 import { Point } from "../Models/Point";
 import { TuckmanActions } from "./Actions";
-import { IUser, IUserList } from "../User/Model";
-import { fromJS, List, Map } from "immutable";
-
+import { IUser, IUserList, IUserUI } from "../User/Model";
 
 const initialSize: Size = new Size(800, 800);
 const initialState: ITuckmanModel = {
-    UserList : {
+    UserList: {
         ShowUsers: true,
         Users: [
-            {Username: "Adam Hall", Focus: "not-in-focus", Y: 0 },
-            {Username: "Caroline Hall", Focus: "not-in-focus", Y: 0 }
-        ],
+            {Username: "Adam Hall", Focus: "not-in-focus", Y: 0},
+            {Username: "Caroline Hall", Focus: "not-in-focus", Y: 0}
+        ]
     },
     Size: initialSize,
-    onHide    : () => {
-        return null;
-    },
-    onShow    : () => {
-        return null;
-    },
+    CenterPoint: new Point(initialSize.width / 2, initialSize.height / 2),
+    onHide: () => undefined,
+    onShow: () => undefined,
     zones: {
-        forming   : {index: 0, label: "forming",    focus: "not-in-focus", Events: undefined, visibility: "appearing"},
-        storming  : {index: 1, label: "storming",   focus: "not-in-focus", Events: undefined, visibility: "appearing"},
-        norming   : {index: 2, label: "norming",    focus: "not-in-focus", Events: undefined, visibility: "appearing"},
+        forming: {index: 0, label: "forming", focus: "not-in-focus", Events: undefined, visibility: "appearing"},
+        storming: {index: 1, label: "storming", focus: "not-in-focus", Events: undefined, visibility: "appearing"},
+        norming: {index: 2, label: "norming", focus: "not-in-focus", Events: undefined, visibility: "appearing"},
         performing: {index: 3, label: "performing", focus: "not-in-focus", Events: undefined, visibility: "appearing"}
     },
     visibility: false,
-    UserChoices: []
-    /*CenterPoint: new Point(initialSize.width / 2, initialSize.height / 2),
-
-    Zones : {
-        Comfort: {Name: "Comfort", Focus: "not-in-focus", Range: {Start: 0, End: 100}, Size: {Width: new DOMMeasurement("50%"), Height: new DOMMeasurement("50%")}},
-        Stretch: {Name: "Stretch", Focus: "not-in-focus", Range: {Start: 100, End: 200}, Size: {Width: new DOMMeasurement("50%"), Height: new DOMMeasurement("50%")}},
-        Chaos: {Name: "Chaos", Focus: "not-in-focus", Range: {Start: 200, End: 300}, Size: {Width: new DOMMeasurement("100%"), Height: new DOMMeasurement("100%")}}
-    },
     ShowUserChoices: false,
-    */
-
+    UserChoices: []
 };
 
 export function tuckmanReducer(state: ITuckmanModel = initialState, action): ITuckmanModel {
     switch (action.type) {
         case TuckmanActions.SET_STAGESIZE:
-            return TuckmanZoneAction.setStageSize(state, (action as any).width, (action as any).height);
+            return TuckmanZoneAction.setStageSize(state, action.width, action.height);
         case TuckmanActions.SET_STAGEVISIBLE:
-            return TuckmanZoneAction.setStageVisibilty(state, (action as any).visibility);
+            return TuckmanZoneAction.setStageVisibilty(state, action.visibility);
         case TuckmanActions.SET_USERFOCUS:
-            return TuckmanZoneAction.setUserFocus(state, (action as any).user, (action as any).focus);
+            return TuckmanZoneAction.setUserFocus(state, action.user, action.focus);
         case TuckmanActions.SET_ZONEFOCUS:
-            return TuckmanZoneAction.setZoneFocus(state, (action as any).area, (action as any).focus);
+            return TuckmanZoneAction.setZoneFocus(state, action.area, action.focus);
         case TuckmanActions.SELECT_USER:
-            return TuckmanZoneAction.selectUser(state, (action as any).user);
+            return TuckmanZoneAction.selectUser(state, action.user);
         case TuckmanActions.CHOOSE_ZONE:
-            return TuckmanZoneAction.chooseZone(state, (action as any).user, (action as any).area, (action as any).distance);
+            return TuckmanZoneAction.chooseZone(state, action.user, action.area, action.distance);
         case TuckmanActions.TOGGLE_CHOICES:
-            return TuckmanZoneAction.toggleChoiceVisibility(state, (action as any).visible);
+            return TuckmanZoneAction.toggleChoiceVisibility(state, action.visible);
         default:
             return state;
     }
 }
-class TuckmanZoneAction {
 
+class TuckmanZoneAction {
     static setStageSize(state: ITuckmanModel, width: number, height: number): ITuckmanModel {
-        const newCenter = new Point(width / 2, height / 2);
-        return fromJS(state)
-            .set("Size", new Size(width, height))
-            .set("CenterPoint", newCenter)
-            .toJS();
+        return {...state, Size: new Size(width, height), CenterPoint: new Point(width / 2, height / 2)};
     }
 
     static setStageVisibilty(state: ITuckmanModel, visibility: "hiding" | "appearing"): ITuckmanModel {
-        return fromJS(state)
-            .setIn(["zones", "forming", "visibility"], visibility)
-            .setIn(["zones", "storming", "visibility"], visibility)
-            .setIn(["zones", "norming", "visibility"], visibility)
-            .setIn(["zones", "performing", "visibility"], visibility).toJS();
+        if (!state.zones) return state;
+        return {
+            ...state,
+            zones: {
+                forming: {...state.zones.forming, visibility},
+                storming: {...state.zones.storming, visibility},
+                norming: {...state.zones.norming, visibility},
+                performing: {...state.zones.performing, visibility}
+            }
+        };
     }
 
     static setZoneFocus(state: ITuckmanModel, area: "forming" | "storming" | "norming" | "performing", focus: "in-focus" | "active" | "not-in-focus"): ITuckmanModel {
-        return fromJS(state)
-            .setIn(["zones", "forming", "focus"], area === "forming" ? focus : "not-in-focus")
-            .setIn(["zones", "storming", "focus"], area === "storming"  ? focus : "not-in-focus")
-            .setIn(["zones", "norming", "focus"], area === "norming"  ? focus : "not-in-focus")
-            .setIn(["zones", "performing", "focus"], area === "performing"  ? focus : "not-in-focus").toJS();
+        if (!state.zones) return state;
+        return {
+            ...state,
+            zones: {
+                forming: {...state.zones.forming, focus: area === "forming" ? focus : "not-in-focus"},
+                storming: {...state.zones.storming, focus: area === "storming" ? focus : "not-in-focus"},
+                norming: {...state.zones.norming, focus: area === "norming" ? focus : "not-in-focus"},
+                performing: {...state.zones.performing, focus: area === "performing" ? focus : "not-in-focus"}
+            }
+        };
     }
 
     static setUserFocus(state: ITuckmanModel, user: string, focus: "in-focus" | "active" | "not-in-focus"): ITuckmanModel {
-        const originalList = List(state.UserList.Users);
-        const newUserList = originalList.update(
-            originalList.findIndex(item => item.Username === user),
-            (item) => fromJS(item).set("Focus", focus)).toJS();
-        return fromJS(state)
-            .setIn(["UserList", "Users"], newUserList).toJS();
+        const users = (state.UserList?.Users ?? []).map((item) =>
+            item.Username === user ? {...item, Focus: focus, Y: "Y" in item ? item.Y : 0} as IUserUI : item
+        );
+        return {...state, UserList: {...state.UserList, Users: users}};
     }
 
     static setUsers(state: ITuckmanModel, userList: IUserList): ITuckmanModel {
-        return fromJS(state)
-            .setIn("UserList", userList).toJS();
+        return {...state, UserList: userList};
     }
 
-    static selectUser(state: ITuckmanModel, user: String): ITuckmanModel {
-        const originalList = List(state.UserList.Users);
-        const item: IUser = originalList.find(item => item.Username === user);
-        // Sets currentUser, and therefor hides the user choice menu
-        const data = fromJS(state)
-            .set("CurrentUser", item)
-            .set("ShowUserChoices", false)
-            .setIn(["UserList", "ShowUsers"], false);
-
-        return data.toJS();
+    static selectUser(state: ITuckmanModel, user: string): ITuckmanModel {
+        const item = (state.UserList?.Users ?? []).find(candidate => candidate.Username === user) as IUser | undefined;
+        return {
+            ...state,
+            CurrentUser: item,
+            ShowUserChoices: false,
+            UserList: {...state.UserList, ShowUsers: false}
+        };
     }
 
-    static chooseZone(
-        state: ITuckmanModel, user: string, area: "forming" | "storming" | "norming" | "performing",
-        distance: number): ITuckmanModel {
-
-        // Add the user choice
-        const newUserChoices = List(state.UserChoices).push({
-            User: {Username: user},
-            Zone: area,
-            Distance: distance
-        }).toJS();
-        // Remove the user from the choice list
-        const newUserList = List(state.UserList.Users).filter((item) => item.Username !== user).toArray();
-        // Show the user list
-        const showUserChoice = !!(newUserList.length);
-        // Return
-        return fromJS(state)
-            .delete("CurrentUser")
-            .set("ShowUserChoices", showUserChoice)
-            .set("UserChoices", newUserChoices)
-            .setIn(["UserList", "Users"], newUserList)
-            .setIn(["UserList", "ShowUsers"], showUserChoice).toJS();
+    static chooseZone(state: ITuckmanModel, user: string, area: "forming" | "storming" | "norming" | "performing", distance: number): ITuckmanModel {
+        const newUserList = (state.UserList?.Users ?? []).filter((item) => item.Username !== user);
+        const showUserChoice = newUserList.length > 0;
+        return {
+            ...state,
+            CurrentUser: undefined,
+            ShowUserChoices: showUserChoice,
+            UserChoices: [...(state.UserChoices ?? []), {User: {Username: user}, Zone: area, Distance: distance}],
+            UserList: {...state.UserList, Users: newUserList, ShowUsers: showUserChoice}
+        };
     }
 
     static toggleChoiceVisibility(state: ITuckmanModel, visible: boolean): ITuckmanModel {
-        // Set "showUserChoices" to true
-        return Map(state)
-            .set("visibility", !visible)
-            .set("ShowUserChoices", visible).toJS();
+        return {...state, visibility: !visible, ShowUserChoices: visible};
     }
 }

--- a/src/React/User/Connector.ts
+++ b/src/React/User/Connector.ts
@@ -9,8 +9,7 @@ const mapStateToProps = (state: ComfortAppState, ownProps: IUserList): IUserList
         ShowUsers: state.UserList.ShowUsers,
         Users: (state.UserList.Users ?? []).map((user, index) => ({
             ...user,
-            Y: (index * 90) + 60,
-            Focus: "Focus" in user ? user.Focus : "not-in-focus"
+            Y: (index * 90) + 60
         } as IUserUI))
     };
 };

--- a/src/React/User/Connector.ts
+++ b/src/React/User/Connector.ts
@@ -2,43 +2,40 @@ import { connect } from "react-redux";
 import { selectUser, setUserFocus } from "../Comfort/Actions";
 import { ComfortAppState } from "../Comfort/Model";
 import { ReduxUserList } from "./Component";
-import { IUserList } from "./Model";
-import { fromJS } from "immutable";
-
+import { IUserList, IUserUI } from "./Model";
 
 const mapStateToProps = (state: ComfortAppState, ownProps: IUserList): IUserList => {
     return {
-      ShowUsers: state.UserList.ShowUsers,
-      Users    : state.UserList.Users.map((u, i) => {
-        return fromJS(u).set("Y", (i * 90) + 60).toJS();
-      })
+        ShowUsers: state.UserList.ShowUsers,
+        Users: (state.UserList.Users ?? []).map((user, index) => ({
+            ...user,
+            Y: (index * 90) + 60,
+            Focus: "Focus" in user ? user.Focus : "not-in-focus"
+        } as IUserUI))
     };
 };
 
-
 const mapDispatchToProps = (dispatch) => {
-  return {
-    events: {
-      onUserMouseDown: (user: string) => {
-        dispatch(setUserFocus(user, "active"));
-      },
-      onUserMouseUp: (user: string, event: any) => {
-        dispatch(setUserFocus(user, "not-in-focus"));
-        dispatch(selectUser(user));
-      },
-      onUserOverFocus: (user: string) => {
-        dispatch(setUserFocus(user, "in-focus"));
-      },
-      onUserOffFocus: (user: string) => {
-        dispatch(setUserFocus(user, "not-in-focus"));
-      }
-    }
-  };
+    return {
+        events: {
+            onUserMouseDown: (user: string) => {
+                dispatch(setUserFocus(user, "active"));
+            },
+            onUserMouseUp: (user: string, event: any) => {
+                dispatch(setUserFocus(user, "not-in-focus"));
+                dispatch(selectUser(user));
+            },
+            onUserOverFocus: (user: string) => {
+                dispatch(setUserFocus(user, "in-focus"));
+            },
+            onUserOffFocus: (user: string) => {
+                dispatch(setUserFocus(user, "not-in-focus"));
+            }
+        }
+    };
 };
 
 export const ReduxUserConnector = connect(
-  mapStateToProps,
-  mapDispatchToProps
+    mapStateToProps,
+    mapDispatchToProps
 )(ReduxUserList);
-
-// UserListConnector

--- a/src/Shared/__tests__/UserConstructor.test.ts
+++ b/src/Shared/__tests__/UserConstructor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { UserConstructor } from '../UserConstructor'
+
+describe('UserConstructor', () => {
+  it('creates users with stable generated ids', () => {
+    const users = UserConstructor.createUsersByNames(['Ada', 'Grace'])
+
+    expect(users).toHaveLength(2)
+    expect(users[0]).toMatchObject({ name: 'Ada', id: 'user0' })
+    expect(users[1]).toMatchObject({ name: 'Grace', id: 'user1' })
+  })
+
+  it('ignores empty names', () => {
+    const users = UserConstructor.createUsersByNames(['Ada', '', 'Grace'])
+
+    expect(users).toHaveLength(2)
+    expect(users.map((user) => user.name)).toEqual(['Ada', 'Grace'])
+  })
+
+  it('creates a single user from a name and index', () => {
+    expect(UserConstructor.createUser('Linus', 4)).toMatchObject({
+      name: 'Linus',
+      id: 'user4',
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
     ],
     "allowJs": true,
     "skipLibCheck": true,
@@ -12,8 +12,8 @@
     "allowSyntheticDefaultImports": true,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,9 @@
     "strictNullChecks": false,
     "noFallthroughCasesInSwitch": true,
     "types": [
-      "vitest/globals"
+      "vite/client",
+      "vitest/globals",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## What changed

- pin the project and CI to Node.js 24
- replace the stale Create React App ESLint metadata with an explicit TypeScript static-analysis gate (`tsc --noEmit`)
- make CI require install, static analysis, Vitest and a Vite production build before deployment
- avoid duplicate branch + PR workflow runs
- add focused tests for user construction/filtering behaviour
- rewrite the README with current Vite/Vercel development, testing, CI/CD and project-structure guidance

## Why

The project already had real Vitest suites and Vercel deployment automation, but its workflow was still on Node 20, did not run a lint/type-check or explicit build before deployment, and the README still described Heroku and `Master` as the deployment path.

## Validation

The PR is left as a draft while GitHub Actions runs `npm ci`, `npm run lint`, `npm run test:ci`, and `npm run build` on Node 24.