### PR TITLE
Group npm and GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,22 @@
 version: 2
+
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      all-npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
TeamTools' workflows are already on `actions/checkout@v7` and `actions/setup-node@v7`. This PR extends Dependabot from npm-only monitoring to both npm and GitHub Actions, grouping compatible updates within each ecosystem.