### PR TITLE
Add CodeQL scanning for TeamTools

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Closes #1015

## Changes
- add JavaScript/TypeScript CodeQL scanning for pull requests and `main`
- add a weekly scheduled scan
- use least-privilege workflow permissions (`actions: read`, `contents: read`, `security-events: write`)
- add concurrency cancellation for superseded scans

## Existing CI
The repository already satisfies the dependency-audit portion of #1015 on `main`: CI uses the declared Node 24 engine and runs both the full dependency audit and production dependency audit before lint, type-check, tests, and build.

## Validation
This PR should run the existing CI pipeline plus the new CodeQL analysis.